### PR TITLE
Don't declare return type to be const void.

### DIFF
--- a/src/tap.h
+++ b/src/tap.h
@@ -146,7 +146,7 @@ private:
 
 	std::map<std::string, tap::TestSet> testCaseTestResultMap;
 
-	const void addTapTestResult(const testing::TestInfo& testInfo) {
+	void addTapTestResult(const testing::TestInfo& testInfo) {
 		std::string testCaseName = testInfo.test_case_name();
 
 		tap::TestResult tapResult;


### PR DESCRIPTION
This is a no-op and trips up some compiler diagnostics.
