### PR TITLE
Add ns-qualifier to std::search

### DIFF
--- a/src/tap.h
+++ b/src/tap.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <fstream>
 #include <string>
+#include <algorithm>
 
 namespace tap {
 
@@ -52,13 +53,13 @@ std::string replace_all_copy(
   auto end = original.end();
   auto current = original.begin();
   auto next =
-    search(current, end, before.begin(), before.end());
+    std::search(current, end, before.begin(), before.end());
 
   while ( next != end ) {
     retval.append( current, next );
     retval.append( after );
     current = next + before.size();
-    next = search(current, end, before.begin(), before.end());
+    next = std::search(current, end, before.begin(), before.end());
   }
   retval.append( current, next );
   return retval;


### PR DESCRIPTION
The namespace qualifier for std::search and the include directive were missing for the call to std::search. This commit adds both.