### PR TITLE
fix(tap.h): Adding '  ...' to correctly end a YAML block

### DIFF
--- a/src/tap.h
+++ b/src/tap.h
@@ -131,7 +131,8 @@ class TestResult {
       ss << std::endl
        << "# Diagnostic" << std::endl
        << "  ---" << std::endl
-       << "  " << replace_all_copy(this->getComment(), "\n", "\n  ");
+       << "  " << replace_all_copy(this->getComment(), "\n", "\n  ") << std::endl
+       << "  ...";
     }
 #endif
     return ss.str();


### PR DESCRIPTION
The [TAP specification](https://testanything.org/tap-version-13-specification.html) requires that yaml description blocks are ended with /^\s+.../